### PR TITLE
Add cpp-boilerplate to the templates list

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ These provide a wide range of functionality - from dealing with compiler flags t
 * [Arduino-CMake-Template](https://github.com/maxbader/Arduino-CMake-Template) - Starting point for Arduino development using CMake. ```[NO LICENSE]```
 * [c-template](https://github.com/fletcher/c-template) - Boilerplate to set up a c project, include CuTest, CMake build setup. [```[MIT]```][MIT]
 * [cpp_project_template](https://github.com/duckie/cpp_project_template) - Simple template to start quickly a C++ project managed by CMake. ```[NO LICENSE]```
+* [cpp-boilerplate](https://github.com/Lectem/cpp-boilerplate) - Template that aims to be a reference for modern CMake and CI [```[MIT]```][MIT]
 
 ## Other
 


### PR DESCRIPTION
This repository was created because it is hard to find a good modern (3.x) CMake template. While it is not perfect, most design choices are documented and CMake anti-patterns are avoided.

Some features :

* Modern CMakeLists.txt, almost fully documented
* CI using travis and appveyor
* tests setup using doctest
* Coverage, by adding a new build type if supported by the compiler
* CTest/CDash setup with script for CI
* some scripts such as :
  - LTO configuration
  - Warnings setup
  - RunFixupBundle.cmake script : A small wrapper around fixup_bundle (no more pain with .DLLs when using visual)
  - ...