### PR TITLE
added Metabench

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Your contributions are highly welcome (first see [CONTRIBUTING.md](CONTRIBUTING.
 * [cmake-modules](https://github.com/hanjianwei/cmake-modules) - [hanjianwei](https://github.com/hanjianwei)'s CMake module collection. [```[MIT]```][MIT]
 * [YCM](https://github.com/robotology/ycm) - Extra CMake Modules for [Yet Another Robot Platform](https://github.com/robotology/yarp) and friends. [```[BSD3]```][BSD-3-Clause]
 * [CMakeCM](https://github.com/vector-of-bool/CMakeCM) - CMake Community Modules. ```[NO LICENSE]```
+* [Metabench](https://github.com/ldionne/metabench) - CMake module for compile-time microbenchmarks. [```[BOOST]```][BOOST]
 
 ## Utility Scripts
 


### PR DESCRIPTION
* [Metabench](https://github.com/ldionne/metabench) - CMake module for compile-time microbenchmarks.