### PR TITLE
Add Arduino CMake Toolchain to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ These provide a wide range of functionality - from dealing with compiler flags t
 * [polly](https://github.com/ruslo/polly) - Collection of CMake toolchain files and scripts for cross-platform build and CI testing. [```[BSD2]```][BSD-2-Clause]
 * [toolchains](https://github.com/mosra/toolchains) - For crosscompiling with CMake. They are meant to be mainly used on ArchLinux. ```[NO LICENSE]```
 * [cmake](https://github.com/staticlibs/cmake/tree/master/toolchains) - Collection of CMake toolchain files, mostly for static linking. [```[APACHE2]```][APACHE2]
+* [Arduino-CMake-Toolchain](https://github.com/a9183756-gh/Arduino-CMake-Toolchain) - CMake toolchain for all official and 3rd party Arduino platforms. [```[MIT]```][MIT]
 
 ## Examples / Templates
 


### PR DESCRIPTION
A toolchain for Arduino compatible boards, that works like
Arduino IDE in supporting all official and unoffical 3rd party
Arduino platforms.