### PR TITLE
Replace mailing list with official Discourse

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Your contributions are highly welcome (first see [CONTRIBUTING.md](CONTRIBUTING.
 * [```#cmake``` on Freenode](http://webchat.freenode.net/?channels=cmake)
 * [```/r/cmake``` on Reddit](https://www.reddit.com/r/cmake/)
 * [```/r/cpp``` on Reddit](https://www.reddit.com/r/cpp/)
-* [Mailing Lists](https://cmake.org/mailing-lists/)
+* [Official Discourse Forum](https://discourse.cmake.org/)
 * [Stack Overflow](http://stackoverflow.com/questions/tagged/cmake)
 
 ## Resources


### PR DESCRIPTION
The CMake mailing list has officially been abandoned in favor of the CMake Discourse.

https://discourse.cmake.org/