### PR TITLE
Add cmakefmt — fast native CMake formatter in Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ These provide a wide range of functionality - from dealing with compiler flags t
 * [cmakeprojectmanager2](https://github.com/h4tr3d/cmakeprojectmanager2) - Enhanced CMake Project Manager plugin for Qt Creator. ```[NO LICENSE]```
 * [cmake-lint](https://github.com/richq/cmake-lint) - Check for coding style issues in CMake files. cmakelint requires Python. [```[APACHE2]```][APACHE2]
 * [git-cmake-format](https://github.com/kbenzie/git-cmake-format) - Integrate clang-format into your CMake project hosted in a git repository. [```[LICENSE]```](https://github.com/kbenzie/git-cmake-format/blob/master/license.txt)
+* [cmakefmt](https://github.com/cmakefmt/cmakefmt) - Fast, native CMake formatter written in Rust with format-on-save editor support and a first-party GitHub Action. [```[MIT]```][MIT]
 * [configure-cmake](https://github.com/nemequ/configure-cmake) - configure-cmake is an autotools-style configure script for CMake-based projects. [```[CC0-1.0]```][CC0-1.0]
 * [cmake-ast](https://github.com/polysquare/cmake-ast) - Python module to reduce a CMake file to an AST. [```[MIT]```][MIT]
 * [cmake-checks-cache](https://github.com/cristianadam/cmake-checks-cache) - CMake checks cache helper modules. [```[MIT]```][MIT]


### PR DESCRIPTION
Adds [cmakefmt](https://cmakefmt.dev) to the Other section, alongside the existing formatting-related entries (`cmake-lint`, `git-cmake-format`).

**cmakefmt** is a fast, native CMake formatter written in Rust:
- Formats `CMakeLists.txt` and `*.cmake` files
- Homebrew, cargo, and pre-built binary installs
- First-party VS Code extension ([Marketplace](https://marketplace.visualstudio.com/items?itemName=cmakefmt.vscode-cmakefmt)) with format-on-save
- First-party GitHub Action (`cmakefmt/cmakefmt-action@v1`)
- MIT OR Apache-2.0 license